### PR TITLE
Update transports.js

### DIFF
--- a/probe/src/js/transports.js
+++ b/probe/src/js/transports.js
@@ -8,7 +8,7 @@ function HTTPMessageTransport(name, receiver, config) {
 HTTPMessageTransport.prototype.makeURL = function(message) {
   var unencoded = JSON.stringify(message);
   var encoded = encodeURI ? encodeURI(unencoded) : escape(unencoded);
-  var URL = this.config.endpoint+"?message="+encoded+'&id='+this.name;
+  var URL = this.config.endpoint+"message="+encoded+'&id='+this.name;
   return URL;
 }
 


### PR DESCRIPTION
Require that the endpoint specifies a URL that can be directly appended to, so that pnh doesnt have to know whether to use ? or &
